### PR TITLE
ported to PowerShell Core for Mac/Linux support

### DIFF
--- a/1-asp-net-core-api-idtokenhint/AppCreationScripts-withCert/AppCreationScripts.md
+++ b/1-asp-net-core-api-idtokenhint/AppCreationScripts-withCert/AppCreationScripts.md
@@ -4,6 +4,8 @@
 
 ### Quick summary
 
+**Note** This version of the app creation scripts can only be used of Windows currently. 
+
 1. On Windows run PowerShell and navigate to the root of the cloned directory
 1. In PowerShell run:
    ```PowerShell
@@ -53,27 +55,22 @@ The `Configure.ps1` will stop if it tries to create an Azure AD application whic
 
 ### Pre-requisites
 
+You must have Powershell installed on your machine. To install it, follow the documentation:
+- [Windows](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.2)
+
 1. Open PowerShell (On Windows, press  `Windows-R` and type `PowerShell` in the search window)
 2. Navigate to the root directory of the project.
 3. Until you change it, the default [Execution Policy](https:/go.microsoft.com/fwlink/?LinkID=135170) for scripts is usually `Restricted`. In order to run the PowerShell script you need to set the Execution Policy to `RemoteSigned`. You can set this just for the current PowerShell process by running the command:
     ```PowerShell
     Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
     ```
-### (Optionally) install AzureAD PowerShell modules
-The scripts install the required PowerShell module (AzureAD) for the current user if needed. However, if you want to install if for all users on the machine, you can follow the following steps:
 
-4. If you have never done it already, in the PowerShell window, install the AzureAD PowerShell modules. For this:
+### Install Az PowerShell modules
+The scripts required PowerShell module Az. To install it, follow the documentation [here](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps?view=azps-7.1.0). If you have installed it previously, make sure that you have the latest version by running Powershell command. The Configure.ps1 script may give an error if you have an old version.
 
-   1. Open PowerShell as admin (On Windows, Search Powershell in the search bar, right click on it and select Run as administrator).
-   2. Type:
-      ```PowerShell
-      Install-Module AzureAD
-      ```
-
-      or if you cannot be administrator on your machine, run:
-      ```PowerShell
-      Install-Module AzureAD -Scope CurrentUser
-      ```
+```powershell
+Update-Module -Name Az
+```
 
 ### Run the script and start running
 

--- a/1-asp-net-core-api-idtokenhint/AppCreationScripts-withCert/Cleanup.ps1
+++ b/1-asp-net-core-api-idtokenhint/AppCreationScripts-withCert/Cleanup.ps1
@@ -5,10 +5,15 @@ param(
     [string] $tenantId
 )
 
-if ((Get-Module -ListAvailable -Name "AzureAD") -eq $null) { 
-    Install-Module "AzureAD" -Scope CurrentUser 
-} 
-Import-Module AzureAD
+# Pre-requisites
+if ($null -eq (Get-Module -ListAvailable -Name "Az.Accounts")) {  
+    Install-Module -Name "Az.Accounts" -Scope CurrentUser 
+}
+if ($null -eq (Get-Module -ListAvailable -Name "Az.Resources")) {  
+    Install-Module "Az.Resources" -Scope CurrentUser 
+}
+Import-Module -Name "Az.Accounts"
+Import-Module -Name "Az.Resources"
 $ErrorActionPreference = 'Stop'
 
 Function Cleanup
@@ -25,36 +30,36 @@ This function removes the Azure AD applications for the sample. These applicatio
     # you'll need to sign-in with creds enabling your to create apps in the tenant)
     if (!$Credential -and $TenantId)
     {
-        $creds = Connect-AzureAD -TenantId $tenantId
+        $creds = Connect-AzAccount -TenantId $tenantId
     }
     else
     {
         if (!$TenantId)
         {
-            $creds = Connect-AzureAD -Credential $Credential
+            $creds = Connect-AzAccount -Credential $Credential
         }
         else
         {
-            $creds = Connect-AzureAD -TenantId $tenantId -Credential $Credential
+            $creds = Connect-AzAccount -TenantId $tenantId -Credential $Credential
         }
     }
-
+    
     if (!$tenantId)
     {
-        $tenantId = $creds.Tenant.Id
+        $tenantId = $creds.Context.Account.Tenants[0]
     }
-    $tenant = Get-AzureADTenantDetail
-    $tenantName =  ($tenant.VerifiedDomains | Where { $_._Default -eq $True }).Name
+    $tenant = Get-AzTenant
+    $tenantDomainName =  ($tenant | Where { $_.Id -eq $tenantId }).Domains[0]
     
     # Removes the applications
-    Write-Host "Cleaning-up applications from tenant '$tenantName'"
+    Write-Host "Cleaning-up applications from tenant '$tenantDomainName'"
 
     Write-Host "Removing 'client' (Verifiable Credentials ASP.Net core sample) if needed"
-    $app=Get-AzureADApplication -Filter "DisplayName eq 'Verifiable Credentials ASP.Net core sample'"  
+    $app = Get-AzADApplication -DisplayName "Verifiable Credentials ASP.Net core sample"  
 
-    if ($app)
+    if ($null -ne $app)
     {
-        Remove-AzureADApplication -ObjectId $app.ObjectId
+        $app | Remove-AzADApplication
         Write-Host "Removed."
     }
 

--- a/1-asp-net-core-api-idtokenhint/AppCreationScripts-withCert/ConfigureVCService.ps1
+++ b/1-asp-net-core-api-idtokenhint/AppCreationScripts-withCert/ConfigureVCService.ps1
@@ -1,7 +1,7 @@
 ﻿[CmdletBinding()]
 param(
     [PSCredential] $Credential,
-    [Parameter(Mandatory=$False, HelpMessage='Tenant ID (This is a GUID which represents the "Directory ID" of the AzureAD tenant into which you want to create the apps')]
+    [Parameter(Mandatory=$True, HelpMessage='Tenant ID (This is a GUID which represents the "Directory ID" of the AzureAD tenant into which you want to create the apps')]
     [string] $tenantId
 )
 
@@ -19,28 +19,35 @@ Function ConfigureVCService
     # you'll need to sign-in with creds enabling your to create apps in the tenant)
     if (!$Credential -and $TenantId)
     {
-        $creds = Connect-AzureAD -TenantId $tenantId
+        $creds = Connect-AzAccount -TenantId $tenantId
     }
     else
     {
         if (!$TenantId)
         {
-            $creds = Connect-AzureAD -Credential $Credential
+            $creds = Connect-AzAccount -Credential $Credential
         }
         else
         {
-            $creds = Connect-AzureAD -TenantId $tenantId -Credential $Credential
+            $creds = Connect-AzAccount -TenantId $tenantId -Credential $Credential
         }
     }
-
-    New-AzureADServicePrincipal -AppId bbb94529-53a3-4be5-a069-7eaf2712b826 -DisplayName "Verifiable Credential Request Service"
+    
+    $appId = "bbb94529-53a3-4be5-a069-7eaf2712b826"
+    if ( $null -eq (Get-AzADServicePrincipal -ApplicationId $appId) ) {
+      New-AzADServicePrincipal -ApplicationId $appId -DisplayName "Verifiable Credential Request Service"
+    }
+    
 }
 
 # Pre-requisites
-if ((Get-Module -ListAvailable -Name "AzureAD") -eq $null) { 
-    Install-Module "AzureAD" -Scope CurrentUser 
-} 
-Import-Module AzureAD
+if ($null -eq (Get-Module -ListAvailable -Name "Az.Accounts")) {  
+    Install-Module -Name "Az.Accounts" -Scope CurrentUser 
+}
+if ($null -eq (Get-Module -ListAvailable -Name "Az.Resources")) {  
+    Install-Module "Az.Resources" -Scope CurrentUser 
+}
+Import-Module -Name "Az.Accounts"
+Import-Module -Name "Az.Resources"
 
 ConfigureVCService -Credential $Credential -tenantId $TenantId
-

--- a/1-asp-net-core-api-idtokenhint/AppCreationScripts/AppCreationScripts.md
+++ b/1-asp-net-core-api-idtokenhint/AppCreationScripts/AppCreationScripts.md
@@ -5,11 +5,12 @@
 ### Quick summary
 
 1. On Windows run PowerShell and navigate to the root of the cloned directory
+1. On Mac/Linux, open a terminal, navigate to the root of the cloned directory, and then run command `pwsh` to start Powershell Core 
 1. In PowerShell run:
    ```PowerShell
    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process -Force
    ```
-1. Run the script to create your Azure AD application and configure the code of the sample application accordinly. (Other ways of running the scripts are described below)
+1. Run the script to create your Azure AD application and configure the code of the sample application accordinly. (Other ways of running the scripts are described below). 
    ```PowerShell
    .\AppCreationScripts\Configure.ps1
    ```
@@ -53,27 +54,17 @@ The `Configure.ps1` will stop if it tries to create an Azure AD application whic
 
 ### Pre-requisites
 
-1. Open PowerShell (On Windows, press  `Windows-R` and type `PowerShell` in the search window)
-2. Navigate to the root directory of the project.
-3. Until you change it, the default [Execution Policy](https:/go.microsoft.com/fwlink/?LinkID=135170) for scripts is usually `Restricted`. In order to run the PowerShell script you need to set the Execution Policy to `RemoteSigned`. You can set this just for the current PowerShell process by running the command:
-    ```PowerShell
-    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
-    ```
-### (Optionally) install AzureAD PowerShell modules
-The scripts install the required PowerShell module (AzureAD) for the current user if needed. However, if you want to install if for all users on the machine, you can follow the following steps:
+You must have Powershell installed on your machine. To install it, follow the documentation:
+- [Windows](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.2)
+- [Mac](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-macos?view=powershell-7.2)
+- [Linux](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-linux?view=powershell-7.2)
 
-4. If you have never done it already, in the PowerShell window, install the AzureAD PowerShell modules. For this:
+### Install Az PowerShell modules
+The scripts required PowerShell module Az. To install it, follow the documentation [here](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps?view=azps-7.1.0). If you have installed it previously, make sure that you have the latest version by running Powershell command. The Configure.ps1 script may give an error if you have an old version.
 
-   1. Open PowerShell as admin (On Windows, Search Powershell in the search bar, right click on it and select Run as administrator).
-   2. Type:
-      ```PowerShell
-      Install-Module AzureAD
-      ```
-
-      or if you cannot be administrator on your machine, run:
-      ```PowerShell
-      Install-Module AzureAD -Scope CurrentUser
-      ```
+```powershell
+Update-Module -Name Az
+```
 
 ### Run the script and start running
 

--- a/1-asp-net-core-api-idtokenhint/AppCreationScripts/Configure.ps1
+++ b/1-asp-net-core-api-idtokenhint/AppCreationScripts/Configure.ps1
@@ -5,6 +5,10 @@ param(
     [string] $tenantId
 )
 
+$cmd = (get-command Add-AzADAppPermission -ErrorAction SilentlyContinue)
+if ( $null -eq $cmd) {
+    Write-Error "You need to update to the latest 'Az' module`nPlease run:`n`nUpdate-Module -Name Az -Force" -ErrorAction Stop
+}
 <#
  This script creates the Azure AD applications needed for this sample and updates the configuration files
  for the visual Studio projects from the data in the Azure AD applications.
@@ -18,86 +22,6 @@ param(
 #>
 
 # Create a password that can be used as an application key
-Function ComputePassword
-{
-    $aesManaged = New-Object "System.Security.Cryptography.AesManaged"
-    $aesManaged.Mode = [System.Security.Cryptography.CipherMode]::CBC
-    $aesManaged.Padding = [System.Security.Cryptography.PaddingMode]::Zeros
-    $aesManaged.BlockSize = 128
-    $aesManaged.KeySize = 256
-    $aesManaged.GenerateKey()
-    return [System.Convert]::ToBase64String($aesManaged.Key)
-}
-
-# Create an application key
-# See https://www.sabin.io/blog/adding-an-azure-active-directory-application-and-key-using-powershell/
-Function CreateAppKey([DateTime] $fromDate, [double] $durationInYears, [string]$pw)
-{
-    $endDate = $fromDate.AddYears($durationInYears) 
-    $keyId = (New-Guid).ToString();
-    $key = New-Object Microsoft.Open.AzureAD.Model.PasswordCredential
-    $key.StartDate = $fromDate
-    $key.EndDate = $endDate
-    $key.Value = $pw
-    $key.KeyId = $keyId
-    return $key
-}
-
-# Adds the requiredAccesses (expressed as a pipe separated string) to the requiredAccess structure
-# The exposed permissions are in the $exposedPermissions collection, and the type of permission (Scope | Role) is 
-# described in $permissionType
-Function AddResourcePermission($requiredAccess, `
-                               $exposedPermissions, [string]$requiredAccesses, [string]$permissionType)
-{
-        foreach($permission in $requiredAccesses.Trim().Split("|"))
-        {
-            foreach($exposedPermission in $exposedPermissions)
-            {
-                if ($exposedPermission.Value -eq $permission)
-                 {
-                    $resourceAccess = New-Object Microsoft.Open.AzureAD.Model.ResourceAccess
-                    $resourceAccess.Type = $permissionType # Scope = Delegated permissions | Role = Application permissions
-                    $resourceAccess.Id = $exposedPermission.Id # Read directory data
-                    $requiredAccess.ResourceAccess.Add($resourceAccess)
-                 }
-            }
-        }
-}
-
-#
-# Exemple: GetRequiredPermissions "Microsoft Graph"  "Graph.Read|User.Read"
-# See also: http://stackoverflow.com/questions/42164581/how-to-configure-a-new-azure-ad-application-through-powershell
-Function GetRequiredPermissions([string] $applicationDisplayName, [string] $requiredDelegatedPermissions, [string]$requiredApplicationPermissions, $servicePrincipal)
-{
-    # If we are passed the service principal we use it directly, otherwise we find it from the display name (which might not be unique)
-    if ($servicePrincipal)
-    {
-        $sp = $servicePrincipal
-    }
-    else
-    {
-        $sp = Get-AzureADServicePrincipal -Filter "DisplayName eq '$applicationDisplayName'"
-    }
-    $appid = $sp.AppId
-    $requiredAccess = New-Object Microsoft.Open.AzureAD.Model.RequiredResourceAccess
-    $requiredAccess.ResourceAppId = $appid 
-    $requiredAccess.ResourceAccess = New-Object System.Collections.Generic.List[Microsoft.Open.AzureAD.Model.ResourceAccess]
-
-    # $sp.Oauth2Permissions | Select Id,AdminConsentDisplayName,Value: To see the list of all the Delegated permissions for the application:
-    if ($requiredDelegatedPermissions)
-    {
-        AddResourcePermission $requiredAccess -exposedPermissions $sp.Oauth2Permissions -requiredAccesses $requiredDelegatedPermissions -permissionType "Scope"
-    }
-    
-    # $sp.AppRoles | Select Id,AdminConsentDisplayName,Value: To see the list of all the Application permissions for the application
-    if ($requiredApplicationPermissions)
-    {
-        AddResourcePermission $requiredAccess -exposedPermissions $sp.AppRoles -requiredAccesses $requiredApplicationPermissions -permissionType "Role"
-    }
-    return $requiredAccess
-}
-
-
 Function UpdateLine([string] $line, [string] $value)
 {
     $index = $line.IndexOf('=')
@@ -152,93 +76,79 @@ Function ConfigureApplications
     # you'll need to sign-in with creds enabling your to create apps in the tenant)
     if (!$Credential -and $TenantId)
     {
-        $creds = Connect-AzureAD -TenantId $tenantId
+        $creds = Connect-AzAccount -TenantId $tenantId
     }
     else
     {
         if (!$TenantId)
         {
-            $creds = Connect-AzureAD -Credential $Credential
+            $creds = Connect-AzAccount -Credential $Credential
         }
         else
         {
-            $creds = Connect-AzureAD -TenantId $tenantId -Credential $Credential
+            $creds = Connect-AzAccount -TenantId $tenantId -Credential $Credential
         }
     }
 
     if (!$tenantId)
     {
-        $tenantId = $creds.Tenant.Id
+        $tenantId = $creds.Context.Account.Tenants[0]
     }
 
-    $tenant = Get-AzureADTenantDetail
-    $tenantName =  ($tenant.VerifiedDomains | Where { $_._Default -eq $True }).Name
+    $tenant = Get-AzTenant
+    $tenantDomainName =  ($tenant | Where { $_.Id -eq $tenantId }).Domains[0]
+    $tenantName =  ($tenant | Where { $_.Id -eq $tenantId }).Name
 
     # Get the user running the script
-    $user = Get-AzureADUser -ObjectId $creds.Account.Id
+    $user = Get-AzADUser -Mail $creds.Context.Account.Id
 
-   # Create the client AAD application
-   Write-Host "Creating the AAD application (Verifiable Credentials ASP.Net core sample)"
-   # Get a 2 years application key for the client Application
-   $pw = ComputePassword
-   $fromDate = [DateTime]::Now;
-   $key = CreateAppKey -fromDate $fromDate -durationInYears 2 -pw $pw
-   $clientAppKey = $pw
-   $clientAadApplication = New-AzureADApplication -DisplayName "Verifiable Credentials ASP.Net core sample" `
-                                                  -IdentifierUris "https://$tenantName/vcaspnetcoresample" `
-                                                  -PasswordCredentials $key `
-                                                  -PublicClient $False
+    # Create the client AAD application
+    Write-Host "Creating the AAD application (Verifiable Credentials ASP.Net core sample)"
+    $clientAadApplication = New-AzADApplication -DisplayName "Verifiable Credentials ASP.Net core sample" `
+                                                -IdentifierUris "https://$tenantDomainName/vcaspnetcoresample" 
+    $clientServicePrincipal = ($clientAadApplication | New-AzADServicePrincipal)
+    # Get a 2 years application key for the client Application
+    $fromDate = [DateTime]::Now
+    $endDate = $fromDate.AddYears(2)
+    $appCreds = ($clientAadApplication | New-AzADAppCredential -StartDate $fromDate -EndDate $endDate)
 
-   $currentAppId = $clientAadApplication.AppId
-   $clientServicePrincipal = New-AzureADServicePrincipal -AppId $currentAppId -Tags {WindowsAzureActiveDirectoryIntegratedApp}
+    # Add Required Resources Access (from 'client' to 'Verifiable Credential Request Service')
+    Write-Host "Getting access from 'client' to 'Microsoft Graph'"
+    $spVCRS = Get-AzADServicePrincipal -DisplayName "Verifiable Credential Request Service"
+    $permissionId = ($spVCRS.AppRole | where {$_.DisplayName -eq "VerifiableCredential.Create.All"}).Id
+    Add-AzADAppPermission -ObjectId $clientAadApplication.Id -ApiId $spVCRS.AppId -PermissionId $permissionId -Type "Role"
+    Write-Host "Granted permissions."
 
-   # add the user running the script as an app owner if needed
-   $owner = Get-AzureADApplicationOwner -ObjectId $clientAadApplication.ObjectId
-   if ($owner -eq $null)
-   { 
-    Add-AzureADApplicationOwner -ObjectId $clientAadApplication.ObjectId -RefObjectId $user.ObjectId
-    Write-Host "'$($user.UserPrincipalName)' added as an application owner to app '$($clientServicePrincipal.DisplayName)'"
-   }
+    Write-Host "Done creating the client application (VC Asp.net core sample)"
 
-   Write-Host "Done creating the client application (VC Asp.net core sample)"
+    # URL of the AAD application in the Azure portal
+    # Future? $clientPortalUrl = "https://portal.azure.com/#@"+$tenantDomainName+"/blade/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/Overview/appId/"+$clientAadApplication.AppId+"/objectId/"+$clientAadApplication.ObjectId+"/isMSAApp/"
+    $clientPortalUrl = "https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/CallAnAPI/appId/"+$clientAadApplication.AppId+"/objectId/"+$clientAadApplication.ObjectId+"/isMSAApp/"
+    Add-Content -Value "<tr><td>client</td><td>$($clientAadApplication.AppId)</td><td><a href='$clientPortalUrl'>VC Asp.net core sample</a></td></tr>" -Path createdApps.html
 
-   # URL of the AAD application in the Azure portal
-   # Future? $clientPortalUrl = "https://portal.azure.com/#@"+$tenantName+"/blade/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/Overview/appId/"+$clientAadApplication.AppId+"/objectId/"+$clientAadApplication.ObjectId+"/isMSAApp/"
-   $clientPortalUrl = "https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/CallAnAPI/appId/"+$clientAadApplication.AppId+"/objectId/"+$clientAadApplication.ObjectId+"/isMSAApp/"
-   Add-Content -Value "<tr><td>client</td><td>$currentAppId</td><td><a href='$clientPortalUrl'>VC Asp.net core sample</a></td></tr>" -Path createdApps.html
+    # Update config file for 'client'
+    $configFile = $pwd.Path + "\..\appsettings.json"
+    Write-Host "Updating the sample code ($configFile)"
+    $dictionary = @{ "TenantId" = $tenantId;"ClientId" = $clientAadApplication.AppId;"ClientSecret" = $appCreds.SecretText };
+    UpdateTextFile -configFilePath $configFile -dictionary $dictionary
+    Write-Host ""
+    Write-Host "IMPORTANT: Please follow the instructions below to complete a few manual step(s) in the Azure portal":
+    Write-Host "- For 'client'"
+    Write-Host "  - Navigate to '$clientPortalUrl'"
+    Write-Host "  - Navigate to the API permissions page and click on 'Grant admin consent for $tenantName'"
 
-   $requiredResourcesAccess = New-Object System.Collections.Generic.List[Microsoft.Open.AzureAD.Model.RequiredResourceAccess]
-
-   # Add Required Resources Access (from 'client' to 'Verifiable Credential Request Service')
-   Write-Host "Getting access from 'client' to 'Microsoft Graph'"
-   $requiredPermissions = GetRequiredPermissions -applicationDisplayName "Verifiable Credential Request Service" `
-                                                -requiredApplicationPermissions "VerifiableCredential.Create.All";
-
-   $requiredResourcesAccess.Add($requiredPermissions)
-
-
-   Set-AzureADApplication -ObjectId $clientAadApplication.ObjectId -RequiredResourceAccess $requiredResourcesAccess
-   Write-Host "Granted permissions."
-
-   # Update config file for 'client'
-   $configFile = $pwd.Path + "\..\appsettings.json"
-   Write-Host "Updating the sample code ($configFile)"
-   $dictionary = @{ "TenantId" = $tenantId;"ClientId" = $clientAadApplication.AppId;"ClientSecret" = $clientAppKey };
-   UpdateTextFile -configFilePath $configFile -dictionary $dictionary
-   Write-Host ""
-   Write-Host "IMPORTANT: Please follow the instructions below to complete a few manual step(s) in the Azure portal":
-   Write-Host "- For 'client'"
-   Write-Host "  - Navigate to '$clientPortalUrl'"
-   Write-Host "  - Navigate to the API permissions page and click on 'Grant admin consent for $tenantName'"
-
-   Add-Content -Value "</tbody></table></body></html>" -Path createdApps.html  
+    Add-Content -Value "</tbody></table></body></html>" -Path createdApps.html  
 }
 
 # Pre-requisites
-if ((Get-Module -ListAvailable -Name "AzureAD") -eq $null) { 
-    Install-Module "AzureAD" -Scope CurrentUser 
-} 
-Import-Module AzureAD
+if ($null -eq (Get-Module -ListAvailable -Name "Az.Accounts")) {  
+    Install-Module -Name "Az.Accounts" -Scope CurrentUser 
+}
+if ($null -eq (Get-Module -ListAvailable -Name "Az.Resources")) {  
+    Install-Module "Az.Resources" -Scope CurrentUser 
+}
+Import-Module -Name "Az.Accounts"
+Import-Module -Name "Az.Resources"
 
 # Run interactively (will ask you for the tenant ID)
 ConfigureApplications -Credential $Credential -tenantId $TenantId

--- a/1-asp-net-core-api-idtokenhint/AppCreationScripts/ConfigureVCService.ps1
+++ b/1-asp-net-core-api-idtokenhint/AppCreationScripts/ConfigureVCService.ps1
@@ -1,7 +1,7 @@
 ﻿[CmdletBinding()]
 param(
     [PSCredential] $Credential,
-    [Parameter(Mandatory=$False, HelpMessage='Tenant ID (This is a GUID which represents the "Directory ID" of the AzureAD tenant into which you want to create the apps')]
+    [Parameter(Mandatory=$True, HelpMessage='Tenant ID (This is a GUID which represents the "Directory ID" of the AzureAD tenant into which you want to create the apps')]
     [string] $tenantId
 )
 
@@ -19,28 +19,35 @@ Function ConfigureVCService
     # you'll need to sign-in with creds enabling your to create apps in the tenant)
     if (!$Credential -and $TenantId)
     {
-        $creds = Connect-AzureAD -TenantId $tenantId
+        $creds = Connect-AzAccount -TenantId $tenantId
     }
     else
     {
         if (!$TenantId)
         {
-            $creds = Connect-AzureAD -Credential $Credential
+            $creds = Connect-AzAccount -Credential $Credential
         }
         else
         {
-            $creds = Connect-AzureAD -TenantId $tenantId -Credential $Credential
+            $creds = Connect-AzAccount -TenantId $tenantId -Credential $Credential
         }
     }
-
-    New-AzureADServicePrincipal -AppId bbb94529-53a3-4be5-a069-7eaf2712b826 -DisplayName "Verifiable Credential Request Service"
+    
+    $appId = "bbb94529-53a3-4be5-a069-7eaf2712b826"
+    if ( $null -eq (Get-AzADServicePrincipal -ApplicationId $appId) ) {
+      New-AzADServicePrincipal -ApplicationId $appId -DisplayName "Verifiable Credential Request Service"
+    }
+    
 }
 
 # Pre-requisites
-if ((Get-Module -ListAvailable -Name "AzureAD") -eq $null) { 
-    Install-Module "AzureAD" -Scope CurrentUser 
-} 
-Import-Module AzureAD
+if ($null -eq (Get-Module -ListAvailable -Name "Az.Accounts")) {  
+    Install-Module -Name "Az.Accounts" -Scope CurrentUser 
+}
+if ($null -eq (Get-Module -ListAvailable -Name "Az.Resources")) {  
+    Install-Module "Az.Resources" -Scope CurrentUser 
+}
+Import-Module -Name "Az.Accounts"
+Import-Module -Name "Az.Resources"
 
 ConfigureVCService -Credential $Credential -tenantId $TenantId
-


### PR DESCRIPTION
## Purpose
The AppCreationScripts have been ported from the AzureAD powershell module to the Az module so it can run under Powershell Core and thereby get support on Mac/Linux platforms.

