### PR TITLE
Fix purpose for presentation requests

### DIFF
--- a/3-asp-net-core-api-b2c/ApiIssuerController.cs
+++ b/3-asp-net-core-api-b2c/ApiIssuerController.cs
@@ -122,7 +122,8 @@ namespace AspNetCoreVerifiableCredentialsB2C
                     includeQRCode = false,
                     authority = this.AppSettings.VerifierAuthority,
                     registration = new Registration() {
-                        clientName = this.AppSettings.client_name
+                        clientName = this.AppSettings.client_name,
+                        purpose = this.AppSettings.Purpose
                     },
                     callback = new Callback() {
                         url = string.Format("{0}/issue-callback", GetApiPath()),

--- a/3-asp-net-core-api-b2c/ApiIssuerController.cs
+++ b/3-asp-net-core-api-b2c/ApiIssuerController.cs
@@ -122,8 +122,7 @@ namespace AspNetCoreVerifiableCredentialsB2C
                     includeQRCode = false,
                     authority = this.AppSettings.VerifierAuthority,
                     registration = new Registration() {
-                        clientName = this.AppSettings.client_name,
-                        purpose = this.AppSettings.Purpose
+                        clientName = this.AppSettings.client_name
                     },
                     callback = new Callback() {
                         url = string.Format("{0}/issue-callback", GetApiPath()),

--- a/3-asp-net-core-api-b2c/ApiVerifierController.cs
+++ b/3-asp-net-core-api-b2c/ApiVerifierController.cs
@@ -56,7 +56,8 @@ namespace AspNetCoreVerifiableCredentialsB2C
                 includeQRCode = false,
                 authority = this.AppSettings.VerifierAuthority,
                 registration = new Registration() {
-                    clientName = this.AppSettings.client_name
+                    clientName = this.AppSettings.client_name,
+                    purpose = this.AppSettings.Purpose
                 },
                 callback = new Callback() {
                     url = string.Format("{0}/presentation-callback", GetApiPath()),
@@ -71,7 +72,6 @@ namespace AspNetCoreVerifiableCredentialsB2C
             request.presentation.requestedCredentials.Add(new RequestedCredential() {
                 type = this.AppSettings.CredentialType,
                 manifest = this.AppSettings.DidManifest,
-                purpose = this.AppSettings.Purpose,
                 acceptedIssuers = new List<string>(new string[] { this.AppSettings.IssuerAuthority })
             });
             return request;

--- a/3-asp-net-core-api-b2c/Models/VCClientApiModels.cs
+++ b/3-asp-net-core-api-b2c/Models/VCClientApiModels.cs
@@ -36,6 +36,7 @@ namespace AspNetCoreVerifiableCredentialsB2C.Models
     public class Registration
     {
         public string clientName { get; set; }
+        public string purpose { get; set; }
     }
 
     /// <summary>
@@ -87,7 +88,6 @@ namespace AspNetCoreVerifiableCredentialsB2C.Models
     {
         public string type { get; set; }
         public string manifest { get; set; }
-        public string purpose { get; set; }
         public List<string> acceptedIssuers { get; set; }
     }
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fixes the purpose being passed to the presentation inside Microsoft Authenticator app

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
* Deploy to sample application or run locally
* Issue a VC then present the presentation QR code to scan
* Scan QR code and see the purpose now shows correctly in the Microsoft Authenticator app

## What to Check
Verify that the following are valid
* Purpose correctly shows in the Microsoft Authenticator app when verifying

## Other Information
<!-- Add any other helpful information that may be needed here. -->