### PR TITLE
fix of FC. add local file as template

### DIFF
--- a/1-asp-net-core-api-idtokenhint/ARMTemplate/template.json
+++ b/1-asp-net-core-api-idtokenhint/ARMTemplate/template.json
@@ -76,7 +76,7 @@
     "PhotoClaimName": {
       "type": "string",
       "metadata": {
-        "description": "claim name for photo - if you are issuing credentials with a photo. Otherwise leave this field blank"
+        "description": "claim name for photo - if you are using FaceCheck during presentation. Otherwise leave this field blank"
       },
       "defaultValue": ""
     }

--- a/1-asp-net-core-api-idtokenhint/CallbackController.cs
+++ b/1-asp-net-core-api-idtokenhint/CallbackController.cs
@@ -48,7 +48,7 @@ namespace AspNetCoreVerifiableCredentials
             _apiKey = System.Environment.GetEnvironmentVariable("API-KEY");
         }
 
-        private async Task<ActionResult> HandleRequestCallback( RequestType requestType, string? body ) {
+        private async Task<ActionResult> HandleRequestCallback( RequestType requestType, string body ) {
             try {
                 this.Request.Headers.TryGetValue( "api-key", out var apiKey );
                 if (requestType != RequestType.Selfie && this._apiKey != apiKey) {
@@ -144,13 +144,15 @@ namespace AspNetCoreVerifiableCredentials
                         result = JObject.FromObject( new { status = requestStatus, message = "QR code is scanned. Waiting for user action..." } );
                         break;
                     case "issuance_error":
-                        result = JObject.FromObject( new { status = requestStatus, message = "Issuance failed: " + reqState["callback"]["error"]["message"] } );
+                        callback = JsonConvert.DeserializeObject<CallbackEvent>( reqState["callback"].ToString() );
+                        result = JObject.FromObject( new { status = requestStatus, message = "Issuance failed: " + callback.error.message } );
                         break;
                     case "issuance_successful":
                         result = JObject.FromObject( new { status = requestStatus, message = "Issuance successful" } );
                         break;
                     case "presentation_error":
-                        result = JObject.FromObject( new { status = requestStatus, message = "Presentation failed:" + reqState["callback"]["error"]["message"] } );
+                        callback = JsonConvert.DeserializeObject<CallbackEvent>( reqState["callback"].ToString() );                        
+                        result = JObject.FromObject( new { status = requestStatus, message = "Presentation failed:" + callback.error.message } );
                         break;
                     case "presentation_verified":
                         callback = JsonConvert.DeserializeObject<CallbackEvent>(reqState["callback"].ToString() );

--- a/1-asp-net-core-api-idtokenhint/MsalAccessTokenHandler.cs
+++ b/1-asp-net-core-api-idtokenhint/MsalAccessTokenHandler.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Web;
+using Microsoft.Extensions.DependencyInjection;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace AspNetCoreVerifiableCredentials {
+    public class MsalAccessTokenHandler {
+        private static X509Certificate2 ReadCertificate( string certificateName ) {
+            if (string.IsNullOrWhiteSpace( certificateName )) {
+                throw new ArgumentException( "certificateName should not be empty. Please set the CertificateName setting in the appsettings.json", "certificateName" );
+            }
+            CertificateDescription certificateDescription = CertificateDescription.FromStoreWithDistinguishedName( certificateName );
+            DefaultCertificateLoader defaultCertificateLoader = new DefaultCertificateLoader();
+            defaultCertificateLoader.LoadIfNeeded( certificateDescription );
+            return certificateDescription.Certificate;
+        }
+
+        public static async Task<(string token, string error, string error_description)> GetAccessToken( IConfiguration configuration) {
+            // You can run this sample using ClientSecret or Certificate. The code will differ only when instantiating the IConfidentialClientApplication
+            string authority = $"{configuration["VerifiedID:Authority"]}{configuration["VerifiedID:TenantId"]}";
+            string clientSecret = configuration.GetValue( "VerifiedID:ClientSecret", "" );
+            // Since we are using application permissions this will be a confidential client application
+            IConfidentialClientApplication app;
+            if (!string.IsNullOrWhiteSpace( clientSecret )) {
+                app = ConfidentialClientApplicationBuilder.Create( configuration["VerifiedID:ClientId"] )
+                    .WithClientSecret( clientSecret )
+                    .WithAuthority( new Uri( authority ) )
+                    .Build();
+            } else {
+                X509Certificate2 certificate = ReadCertificate( configuration["VerifiedID:CertificateName"] );
+                app = ConfidentialClientApplicationBuilder.Create( configuration["VerifiedID:ClientId"] )
+                    .WithCertificate( certificate )
+                    .WithAuthority( new Uri( authority ) )
+                    .Build();
+            }
+
+            //configure in memory cache for the access tokens. The tokens are typically valid for 60 seconds,
+            //so no need to create new ones for every web request
+            app.AddDistributedTokenCache( services => {
+                services.AddDistributedMemoryCache();
+                services.AddLogging( configure => configure.AddConsole() )
+                .Configure<LoggerFilterOptions>( options => options.MinLevel = Microsoft.Extensions.Logging.LogLevel.Debug );
+            } );
+
+            // With client credentials flows the scopes is ALWAYS of the shape "resource/.default", as the 
+            // application permissions need to be set statically (in the portal or by PowerShell), and then granted by
+            // a tenant administrator. 
+            string[] scopes = new string[] { configuration["VerifiedID:scope"] };
+
+            AuthenticationResult result = null;
+            try {
+                result = await app.AcquireTokenForClient( scopes )
+                    .ExecuteAsync();
+            } catch (MsalServiceException ex) when (ex.Message.Contains( "AADSTS70011" )) {
+                // Invalid scope. The scope has to be of the form "https://resourceurl/.default"
+                // Mitigation: change the scope to be as expected
+                return (string.Empty, "500", "Scope provided is not supported");
+                //return BadRequest(new { error = "500", error_description = "Scope provided is not supported" });
+            } catch (MsalServiceException ex) {
+                // general error getting an access token
+                return (String.Empty, "500", "Something went wrong getting an access token for the client API:" + ex.Message);
+                //return BadRequest(new { error = "500", error_description = "Something went wrong getting an access token for the client API:" + ex.Message });
+            }
+
+            return (result.AccessToken, String.Empty, String.Empty);
+        }
+
+    }
+}

--- a/1-asp-net-core-api-idtokenhint/README.md
+++ b/1-asp-net-core-api-idtokenhint/README.md
@@ -19,13 +19,30 @@ Welcome to Microsoft Entra Verified ID. In this sample, we'll teach you to issue
 
 ## Deploy to Azure
 
+Complete the [setup](#Setup) before deploying to Azure so that you have all the required parameters.
+
+
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure-Samples%2Factive-directory-verifiable-credentials-dotnet%2Fmain%2F1-asp-net-core-api-idtokenhint%2FARMTemplate%2Ftemplate.json)
 
 You will be asked to enter some parameters during deployment about your app registration and your Verified ID details. You will find these values in the admin portal. 
 
 ![Deployment Parameters](ReadmeFiles/DeployToAzure.png)
 
-Please complete the [setup](Setup) before deploying to Azure.
+The `photo` claim is for presentation to name the claim in the requested credential when asking for a `FaceCheck`. 
+For issuance, the sample will use the credential manifest to determind if the credential has a photo or not. 
+If you have a claim with a [type](https://learn.microsoft.com/en-us/entra/verified-id/rules-and-display-definitions-model#displayclaims-type) of `image/jpg;base64ur`, then the sample will add the selfie or uploaded photo to that claim during issuance. 
+
+## Additional appsettings that can be used after deployment
+
+These settings can be set in the deployed AppServices Environment Variables configuration. In AppServices, they need to have a name like `VerifiedID__PhotoClaimName`, ie prefixed by `VerifiedID` followed by a double underscore to match the hierarchy in the appsettingsfile.
+
+| Key | value | Description |
+|------|--------|--------|
+| IssuancePinCodeLength | 0-6 | Length of pin code. A value of 0 means not to use pin code during issuance. Pin code is only supported for [idTokenHint flow](https://learn.microsoft.com/en-us/entra/verified-id/how-to-use-quickstart). If the webapp is used on a mobile device, the sample eliminates the pin code as it makes no sense. |
+| useFaceCheck | true/false | If to use FaceCheck during presentation requests. This requires that the credential type asked for has a photo claim. |
+| PhotoClaimName | claim name | The name of the claim in the credential type asked for during presentation when `useFaceCheck` is `true`. The PhotoClaimName is not used during issuance. If the credential manifest has a claim with a type of `image/jpg;base64ur`, that claim will hold the photo. |
+| matchConfidenceThreshold | 50-100 | Optional. Confidence threshold for a successful FaceCheck. Default is 70 |
+| CredentialExpiration | any or EOD, EOW, EOQ, EOY or ""| Optional. In [idTokenHint flow](https://learn.microsoft.com/en-us/entra/verified-id/how-to-use-quickstart) you can now set the expiration date of the issued credential. This sample illustrates this by giving you the option of setting the expiry date to a calculated value. EOW means end-of-week, EOQ end-of-quearter, etc. |
 
 ## Test Issuance and Verification
 
@@ -37,17 +54,19 @@ If you want to test presenting and verifying other types and credentials, follow
 
 The sample creates a [presentation request](https://learn.microsoft.com/en-us/entra/verified-id/get-started-request-api?tabs=http%2Cconstraints#presentation-request-example) in code based on your configuration in `appsettings.json`. 
 You can also use JSON templates to create other presentation requests without changing the configuration to quickly test different scenarios. 
-This github repo provises four templates for your convenience. Right-click and copy the below links and change `localhost` to your webapp's hostname. 
+This github repo provises four templates for your convenience. Right-click and copy the below links and append it to your deployed webapp so you have a URL that looks like `.../verifier?template=https://...`. 
 You can issue yourself a `VerifiedEmployee` credential at [MyAccount](https://myaccound.microsoft.com) if your organization have onboarded to Verified ID and enabled MyAccount (doc [here](https://learn.microsoft.com/en-us/entra/verified-id/verifiable-credentials-configure-tenant-quick#myaccount-available-now-to-simplify-issuance-of-workplace-credentials)).
 
 | Template | Description | Link |
 |------|--------|--------|
-| TrueIdentity | A presentation request for a [TrueIdentity](https://trueidentityinc.azurewebsites.net/) credential | [Link](http://localhost/verifier?template=https://raw.githubusercontent.com/Azure-Samples/active-directory-verifiable-credentials-dotnet/main/1-asp-net-core-api-idtokenhint/Templates/presentation_request_TrueIdentity.json) |
-| VerifiedEmployee | A presentation request for a [VerifiedEmployee](https://learn.microsoft.com/en-us/entra/verified-id/how-to-use-quickstart-verifiedemployee) credential | [Link](http://localhost/verifier?template=https://raw.githubusercontent.com/Azure-Samples/active-directory-verifiable-credentials-dotnet/main/1-asp-net-core-api-idtokenhint/Templates/presentation_request_VerifiedEmployee.json) |
-| VerifiedEmployee with FaceCheck*| A presentation request for a VerifiedEmployee credential that will perform a liveness check in the Authenticator. This requires that you have a good photo of yourself in the VerifiedEmployee credential | [Link](http://localhost/verifier?template=https://raw.githubusercontent.com/Azure-Samples/active-directory-verifiable-credentials-dotnet/main/1-asp-net-core-api-idtokenhint/Templates/presentation_request_VerifiedEmployee-FaceCheck.json) |
-| VerifiedEmployee with constraints | A presentation request for a VerifiedEmployee credential that uses a claims constraints that `jobTitle` contains the word `manager` | [Link](http://localhost/verifier?template=https://raw.githubusercontent.com/Azure-Samples/active-directory-verifiable-credentials-dotnet/main/1-asp-net-core-api-idtokenhint/Templates/presentation_request_VerifiedEmployee-Constraints.json) |
+| TrueIdentity | A presentation request for a [TrueIdentity](https://trueidentityinc.azurewebsites.net/) credential | [Link](?template=https://raw.githubusercontent.com/Azure-Samples/active-directory-verifiable-credentials-dotnet/main/1-asp-net-core-api-idtokenhint/Templates/presentation_request_TrueIdentity.json) |
+| VerifiedEmployee | A presentation request for a [VerifiedEmployee](https://learn.microsoft.com/en-us/entra/verified-id/how-to-use-quickstart-verifiedemployee) credential | [Link](?template=https://raw.githubusercontent.com/Azure-Samples/active-directory-verifiable-credentials-dotnet/main/1-asp-net-core-api-idtokenhint/Templates/presentation_request_VerifiedEmployee.json) |
+| VerifiedEmployee with FaceCheck*| A presentation request for a VerifiedEmployee credential that will perform a liveness check in the Authenticator. This requires that you have a good photo of yourself in the VerifiedEmployee credential | [Link](?template=https://raw.githubusercontent.com/Azure-Samples/active-directory-verifiable-credentials-dotnet/main/1-asp-net-core-api-idtokenhint/Templates/presentation_request_VerifiedEmployee-FaceCheck.json) |
+| VerifiedEmployee with constraints | A presentation request for a VerifiedEmployee credential that uses a claims constraints that `jobTitle` contains the word `manager` | [Link](?template=https://raw.githubusercontent.com/Azure-Samples/active-directory-verifiable-credentials-dotnet/main/1-asp-net-core-api-idtokenhint/Templates/presentation_request_VerifiedEmployee-Constraints.json) |
 
 *Note - FaceCheck is in preview. If you plan to test it, make sure you have the latest Microsoft Authenticator.
+
+You can also use a local file as your template. In this case the template link will be a local file path, like `.../verifier?template=C:\Users\foobar\something\my-presentation-request.json`.
 
 ## Contents
 

--- a/1-asp-net-core-api-idtokenhint/Templates/presentation_request_VerifiedEmployee-FaceCheck.json
+++ b/1-asp-net-core-api-idtokenhint/Templates/presentation_request_VerifiedEmployee-FaceCheck.json
@@ -21,11 +21,11 @@
       "configuration": {
         "validation": {
           "allowRevoked": true,
-          "validateLinkedDomain": true
-        },
-        "faceCheck": {
-          "sourcePhotoClaimName": "photo",
-          "matchConfidenceThreshold": 70
+          "validateLinkedDomain": true,
+          "faceCheck": {
+            "sourcePhotoClaimName": "photo",
+            "matchConfidenceThreshold": 70
+          }
         }
       }
     }


### PR DESCRIPTION
Fixed the following

- photo claim is taken from manifest during issuance
- presentation_error callback handling bug
- template link can be a local file
- correction of VerifiedEmployee-FaceCheck.json template
- template links in README are relative