### PR TITLE
rm setting default value for CredentialExpiration in appsettings.json

### DIFF
--- a/3-asp-net-core-api-b2c/appsettings.json
+++ b/3-asp-net-core-api-b2c/appsettings.json
@@ -50,7 +50,7 @@
     "useFaceCheck": false,
     "PhotoClaimName": "photo",
     "matchConfidenceThreshold": 70,
-    "CredentialExpiration": "EOQ" // EOD, EOW, EOQ, EOY, "". Only valid for idTokenHint flows
+    "CredentialExpiration": "" // EOD, EOW, EOQ, EOY, "". Only valid for idTokenHint flows
   }
 
 }


### PR DESCRIPTION
- remove having a default value for CredentialExpiration in appsettings.json to avoid getting error message about expiry