### PR TITLE
rm default value for CredentialExpiration

### DIFF
--- a/1-asp-net-core-api-idtokenhint/appsettings.json
+++ b/1-asp-net-core-api-idtokenhint/appsettings.json
@@ -35,7 +35,7 @@
     "useFaceCheck": false,
     "PhotoClaimName": "photo",
     "matchConfidenceThreshold": 70,
-    "CredentialExpiration": "EOQ" // EOD, EOW, EOQ, EOY, "". Only valid for idTokenHint flows
+    "CredentialExpiration": "" // EOD, EOW, EOQ, EOY, "". Only valid for idTokenHint flows
   }
 
 }


### PR DESCRIPTION
removed the default value for CredentialExpiration in appsettigs.json. You should set it when you want to use it