### PR TITLE
rm remoteDebuggingVersion in ARM templates

### DIFF
--- a/1-asp-net-core-api-idtokenhint/ARMTemplate/template.json
+++ b/1-asp-net-core-api-idtokenhint/ARMTemplate/template.json
@@ -260,7 +260,6 @@
         "netFrameworkVersion": "v6.0",
         "requestTracingEnabled": false,
         "remoteDebuggingEnabled": false,
-        "remoteDebuggingVersion": "VS2019",
         "httpLoggingEnabled": true,
         "acrUseManagedIdentityCreds": false,
         "logsDirectorySizeLimit": 35,

--- a/2-asp-net-core-api-user-signin/ARMTemplate/template.json
+++ b/2-asp-net-core-api-user-signin/ARMTemplate/template.json
@@ -268,7 +268,6 @@
         "netFrameworkVersion": "v6.0",
         "requestTracingEnabled": false,
         "remoteDebuggingEnabled": false,
-        "remoteDebuggingVersion": "VS2019",
         "httpLoggingEnabled": true,
         "acrUseManagedIdentityCreds": false,
         "logsDirectorySizeLimit": 35,

--- a/3-asp-net-core-api-b2c/ARMTemplate/template.json
+++ b/3-asp-net-core-api-b2c/ARMTemplate/template.json
@@ -336,7 +336,6 @@
           "netFrameworkVersion": "v6.0",
           "requestTracingEnabled": false,
           "remoteDebuggingEnabled": false,
-          "remoteDebuggingVersion": "VS2019",
           "httpLoggingEnabled": true,
           "acrUseManagedIdentityCreds": false,
           "logsDirectorySizeLimit": 35,

--- a/4-externalid-verifiedid/ARMTemplate/template.json
+++ b/4-externalid-verifiedid/ARMTemplate/template.json
@@ -302,7 +302,6 @@
           "netFrameworkVersion": "v6.0",
           "requestTracingEnabled": false,
           "remoteDebuggingEnabled": false,
-          "remoteDebuggingVersion": "VS2019",
           "httpLoggingEnabled": true,
           "acrUseManagedIdentityCreds": false,
           "logsDirectorySizeLimit": 35,

--- a/5-onboard-with-tap/ARMTemplate/template.json
+++ b/5-onboard-with-tap/ARMTemplate/template.json
@@ -272,7 +272,6 @@
         "netFrameworkVersion": "v6.0",
         "requestTracingEnabled": false,
         "remoteDebuggingEnabled": false,
-        "remoteDebuggingVersion": "VS2019",
         "httpLoggingEnabled": true,
         "acrUseManagedIdentityCreds": false,
         "logsDirectorySizeLimit": 35,

--- a/6-woodgrove-helpdesk/ARMTemplate/template.json
+++ b/6-woodgrove-helpdesk/ARMTemplate/template.json
@@ -205,7 +205,6 @@
         "netFrameworkVersion": "v6.0",
         "requestTracingEnabled": false,
         "remoteDebuggingEnabled": false,
-        "remoteDebuggingVersion": "VS2019",
         "httpLoggingEnabled": true,
         "acrUseManagedIdentityCreds": false,
         "logsDirectorySizeLimit": 35,


### PR DESCRIPTION
removed the remoteDebuggingVersion attribute as remote debugging isn't enabled