### PR TITLE
Sample 7: fix Deploy-to-Azure button URL and createUiDefinition staleness

### DIFF
--- a/7-AccountRecovery-ClaimsMatching/ARMTemplate/createUiDefinition.json
+++ b/7-AccountRecovery-ClaimsMatching/ARMTemplate/createUiDefinition.json
@@ -6,7 +6,7 @@
     "config": {
       "isWizard": true,
       "basics": {
-        "description": "**Account Recovery Claims Matching API**\n\nDeploys an Azure Function App that handles Microsoft Entra **Custom Authentication Extension** callouts during the Verified ID account-recovery flow.\n\nRuns on a **B1 (Basic) App Service plan** with `alwaysOn=true` so the first CAE call after idle does not cold-start. The function code is deployed from this repo via Kudu sourcecontrols. First deploy takes ~2 minutes; subsequent ARM deploys reuse the running app."
+        "description": "**Account Recovery Claims Matching API**\n\nDeploys an Azure Function App that handles Microsoft Entra **Custom Authentication Extension** callouts during the Verified ID account-recovery flow.\n\nRuns on a **Y1 Consumption plan** (serverless, pay-per-execution). The function code is deployed from this repo via Kudu sourcecontrols. First deploy takes ~2 minutes; subsequent ARM deploys reuse the running app."
       }
     },
     "basics": [
@@ -25,8 +25,8 @@
         "name": "dotnetVersion",
         "type": "Microsoft.Common.DropDown",
         "label": ".NET version",
-        "defaultValue": ".NET 8 (LTS)",
-        "toolTip": "Runtime version for the .NET isolated worker. v8.0 (LTS) is preinstalled everywhere; v10.0 may require an SDK download on first deploy.",
+        "defaultValue": ".NET 10",
+        "toolTip": "Runtime version for the .NET isolated worker. v10.0 is the default; v8.0 (LTS) is also supported.",
         "constraints": {
           "allowedValues": [
             { "label": ".NET 8 (LTS)", "value": "v8.0"  },

--- a/7-AccountRecovery-ClaimsMatching/README.md
+++ b/7-AccountRecovery-ClaimsMatching/README.md
@@ -165,7 +165,7 @@ The `claims` object is **dynamic** — you can include any set of key/value pair
 
 ### Deploy to Azure
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Frogulati%2FAccountRecoveryClaimsMatchingAPI%2Fmain%2FARMTemplate%2Ftemplate.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure-Samples%2Factive-directory-verifiable-credentials-dotnet%2Fmain%2F7-AccountRecovery-ClaimsMatching%2FARMTemplate%2Ftemplate.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure-Samples%2Factive-directory-verifiable-credentials-dotnet%2Fmain%2F7-AccountRecovery-ClaimsMatching%2FARMTemplate%2FcreateUiDefinition.json)
 
 You will be prompted for the following parameters:
 


### PR DESCRIPTION
Follow-up to #102 (merged just before these edits landed on the branch).

## Changes

**README.md**
- Deploy-to-Azure button URL was still pointing at the rogulati fork (`raw.githubusercontent.com/rogulati/AccountRecoveryClaimsMatchingAPI/main/...`). Updated to the canonical Azure-Samples path: `raw.githubusercontent.com/Azure-Samples/active-directory-verifiable-credentials-dotnet/main/7-AccountRecovery-ClaimsMatching/ARMTemplate/template.json`.
- Added `createUIDefinitionUri` segment so the wizard (createUiDefinition.json shipped in #102) actually loads when the button is clicked.

**ARMTemplate/createUiDefinition.json**
- Wizard description said `B1 (Basic) App Service plan with alwaysOn=true` but template.json deploys `Y1` Consumption. Corrected text.
- `dotnetVersion` defaultValue was `.NET 8 (LTS)` while template.json default is `v10.0`. Set wizard default to `.NET 10` so the two stay in sync.
