### PR TITLE
Sample 7: clarify Consumption plan is Y1 in README (replaces #103)

### DIFF
--- a/7-AccountRecovery-ClaimsMatching/ARMTemplate/createUiDefinition.json
+++ b/7-AccountRecovery-ClaimsMatching/ARMTemplate/createUiDefinition.json
@@ -6,7 +6,7 @@
     "config": {
       "isWizard": true,
       "basics": {
-        "description": "**Account Recovery Claims Matching API**\n\nDeploys an Azure Function App that handles Microsoft Entra **Custom Authentication Extension** callouts during the Verified ID account-recovery flow.\n\nRuns on a **B1 (Basic) App Service plan** with `alwaysOn=true` so the first CAE call after idle does not cold-start. The function code is deployed from this repo via Kudu sourcecontrols. First deploy takes ~2 minutes; subsequent ARM deploys reuse the running app."
+        "description": "**Account Recovery Claims Matching API**\n\nDeploys an Azure Function App that handles Microsoft Entra **Custom Authentication Extension** callouts during the Verified ID account-recovery flow.\n\nRuns on a **Y1 Consumption plan** (serverless, pay-per-execution). The function code is deployed from this repo via Kudu sourcecontrols. First deploy takes ~2 minutes; subsequent ARM deploys reuse the running app."
       }
     },
     "basics": [
@@ -25,8 +25,8 @@
         "name": "dotnetVersion",
         "type": "Microsoft.Common.DropDown",
         "label": ".NET version",
-        "defaultValue": ".NET 8 (LTS)",
-        "toolTip": "Runtime version for the .NET isolated worker. v8.0 (LTS) is preinstalled everywhere; v10.0 may require an SDK download on first deploy.",
+        "defaultValue": ".NET 10",
+        "toolTip": "Runtime version for the .NET isolated worker. v10.0 is the default; v8.0 (LTS) is also supported.",
         "constraints": {
           "allowedValues": [
             { "label": ".NET 8 (LTS)", "value": "v8.0"  },

--- a/7-AccountRecovery-ClaimsMatching/README.md
+++ b/7-AccountRecovery-ClaimsMatching/README.md
@@ -189,7 +189,7 @@ You will be prompted for the following parameters:
 | **.NET Version** | *(optional)* `.NET` runtime version — `v10.0` (default) or `v8.0`. Use `v8.0` if .NET 10 is not yet available in your region |
 
 The template deploys **both infrastructure and code**:
-- **Azure Function App** (Consumption plan, .NET isolated worker, v4 runtime)
+- **Azure Function App** (Consumption plan (Y1), .NET isolated worker, v4 runtime)
 - **Source control integration** — automatically pulls and builds the function code from the GitHub repository
 - **Storage Account** — Required runtime dependency for Azure Functions on the Consumption plan. The Functions host uses it for trigger management and internal orchestration (`AzureWebJobsStorage`). On Consumption plans, it also hosts an Azure Files share that stores the deployed function code for scale-out (`WEBSITE_CONTENTSHARE`). Your application code does not interact with it directly. The storage account name is derived from the function app name (first 10 alphanumeric characters) plus a unique hash and `sa` suffix (e.g., `acctrecovexi1q2r3s4tsa`), making it easy to identify in the Azure portal.
 - **Application Insights** for monitoring and logging

--- a/7-AccountRecovery-ClaimsMatching/README.md
+++ b/7-AccountRecovery-ClaimsMatching/README.md
@@ -165,7 +165,7 @@ The `claims` object is **dynamic** — you can include any set of key/value pair
 
 ### Deploy to Azure
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Frogulati%2FAccountRecoveryClaimsMatchingAPI%2Fmain%2FARMTemplate%2Ftemplate.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure-Samples%2Factive-directory-verifiable-credentials-dotnet%2Fmain%2F7-AccountRecovery-ClaimsMatching%2FARMTemplate%2Ftemplate.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure-Samples%2Factive-directory-verifiable-credentials-dotnet%2Fmain%2F7-AccountRecovery-ClaimsMatching%2FARMTemplate%2FcreateUiDefinition.json)
 
 You will be prompted for the following parameters:
 


### PR DESCRIPTION
## Summary

Replaces closed PR #103. This PR carries forward the Deploy-to-Azure button / `createUiDefinition.json` staleness fix **and** adds an explicit **(Y1)** label to the README so the hosting plan is unambiguous.

## Changes

- **README** — Deploy-to-Azure section now reads "**Azure Function App** (Consumption plan **(Y1)**, .NET isolated worker, v4 runtime)" so readers can directly map the description to the `Microsoft.Web/serverfarms` SKU (`name: Y1`, `tier: Dynamic`) in `ARMTemplate/template.json`.
- Includes the Sample 7 Deploy-to-Azure button URL + `createUiDefinition.json` fix from the (now closed) #103.

## Why

The template provisions a **Y1 Consumption** plan, but the README only said "Consumption plan". Naming the SKU explicitly removes ambiguity for anyone validating the ARM template or troubleshooting the plan tier.

## Validation

- `createUiDefinition.json` outputs verified to map 1:1 to all 17 `template.json` parameters.
- Deploy-to-Azure button URL confirmed to resolve to the correct `template.json` and `createUiDefinition.json` on `main`.
- Docs-only README change in the deploy section; no functional/code impact.
